### PR TITLE
Run plugin initialization on `plugins_loaded` hook

### DIFF
--- a/genesis-js-no-js.php
+++ b/genesis-js-no-js.php
@@ -37,41 +37,51 @@ if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
-if ( version_compare( PHP_VERSION, '7.1', '<' ) ) {
-	if ( current_user_can( 'activate_plugins' ) ) {
-		add_action( 'admin_init', 'genesis_js_no_js_deactivate' );
-		add_action( 'admin_notices', 'genesis_js_no_js_deactivation_notice' );
-
-		/**
-		 * Deactivate the plugin.
-		 */
-		function genesis_js_no_js_deactivate() {
-			deactivate_plugins( plugin_basename( __FILE__ ) );
+add_action( 'plugins_loaded', 'genesis_js_no_js_initialise_plugin' );
+/**
+ * Initialise the plugin.
+ *
+ * @since 3.1.0
+ *
+ * @return mixed
+ */
+function genesis_js_no_js_initialise_plugin() {
+	if ( version_compare( PHP_VERSION, '7.1', '<' ) ) {
+		if ( current_user_can( 'activate_plugins' ) ) {
+			add_action( 'admin_init', 'genesis_js_no_js_deactivate' );
+			add_action( 'admin_notices', 'genesis_js_no_js_deactivation_notice' );
 		}
 
-		/**
-		 * Show deactivation admin notice.
-		 */
-		function genesis_js_no_js_deactivation_notice() {
-			$notice = sprintf(
-				// Translators: 1: Required PHP version, 2: Current PHP version.
-				'<strong>Plugin name</strong> requires PHP %1$s to run. This site uses %2$s, so the plugin has been <strong>deactivated</strong>.',
-				'7.1',
-				PHP_VERSION
-			);
-			?>
-			<div class="updated"><p><?php echo wp_kses_post( $notice ); ?></p></div>
-			<?php
-			if ( isset( $_GET['activate'] ) ) { // WPCS: input var okay, CSRF okay.
-				unset( $_GET['activate'] ); // WPCS: input var okay.
-			}
-		}
+		return false;
 	}
 
-	return false;
+	/**
+	 * Load plugin initialisation file.
+	 */
+	require plugin_dir_path( __FILE__ ) . '/init.php';
 }
 
 /**
- * Load plugin initialisation file.
+ * Deactivate the plugin.
  */
-require plugin_dir_path( __FILE__ ) . '/init.php';
+function genesis_js_no_js_deactivate() {
+	deactivate_plugins( plugin_basename( __FILE__ ) );
+}
+
+/**
+ * Show deactivation admin notice.
+ */
+function genesis_js_no_js_deactivation_notice() {
+	$notice = sprintf(
+		// Translators: 1: Required PHP version, 2: Current PHP version.
+		'<strong>Genesis JS / No JS</strong> requires PHP %1$s to run. This site uses %2$s, so the plugin has been <strong>deactivated</strong>.',
+		'7.1',
+		PHP_VERSION
+	);
+	?>
+	<div class="updated"><p><?php echo wp_kses_post( $notice ); ?></p></div>
+	<?php
+	if ( isset( $_GET['activate'] ) ) { // WPCS: input var okay, CSRF okay.
+		unset( $_GET['activate'] ); // WPCS: input var okay.
+	}
+}


### PR DESCRIPTION
## Description
When the PHP requirement is not met the plugin begins the deactivation process, first checking if a notice should be displayed to the user.  Apparently it is necessary to hook into the WP event cycle so that the function `wp_get_current_user()` is available. I tested the `plugins_loaded` and `init` hooks. Both worked but I opted to use the earlier hook.

## Motivation and Context
Fixes #7

## How Has This Been Tested?
I tested locally using PHP 5.6, 7.0, and 7.1. When the PHP requirement is met the plugin works as expected: `no-js` is replaced with `js` when JavaScript is available. When the PHP requirement is not met, the plugin deactivates with a notice in WP Admin.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project. (I even used the British spelling of initialisation!)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING] document.
